### PR TITLE
Docker-compose added

### DIFF
--- a/docker-compose/default-tables.sql
+++ b/docker-compose/default-tables.sql
@@ -1,0 +1,131 @@
+CREATE TABLE IF NOT EXISTS customerType(
+    id int(11) NOT NULL AUTO_INCREMENT,
+    description varchar(200) NOT NULL,
+
+    PRIMARY KEY(id)
+) ENGINE=INNODB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
+
+CREATE TABLE IF NOT EXISTS customer (
+    id int(11)  NOT NULL AUTO_INCREMENT,
+    name varchar(50) NOT NULL,
+    surname varchar(50)NOT NULL,
+    email varchar(50) NOT NULL,
+    phone varchar(20) NOT NULL,
+    type int(11) NOT NULL,
+
+    PRIMARY KEY (id),
+    FOREIGN KEY (type) REFERENCES customerType(id)
+) ENGINE=INNODB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
+
+CREATE TABLE IF NOT EXISTS companyType(
+    id int(11) NOT NULL AUTO_INCREMENT,
+    description varchar(200) NOT NULL,
+
+    PRIMARY KEY(id)
+) ENGINE=INNODB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
+
+CREATE TABLE IF NOT EXISTS companySector(
+    id int(11) unsigned NOT NULL AUTO_INCREMENT,
+    description varchar(200) NOT NULL,
+    
+    PRIMARY KEY(id)
+)ENGINE=INNODB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
+
+CREATE TABLE IF NOT EXISTS company(
+    id int(11) unsigned NOT NULL AUTO_INCREMENT,
+    name varchar(50) NOT NULL,
+    type int(11) NOT NULL,
+    description varchar(200) NULL,
+    sector int(11) NOT NULL,
+
+    PRIMARY KEY(id,type,sector),
+    FOREIGN KEY (type) REFERENCES companyType(id)
+) ENGINE=INNODB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
+
+
+CREATE TABLE IF NOT EXISTS uom(
+    /* unit of measure */
+    id int(11) NOT NULL AUTO_INCREMENT,
+    shortName varchar(5) NOT NULL,
+    description varchar(50) NOT NULL,
+
+    PRIMARY KEY(id)
+) ENGINE=INNODB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
+
+CREATE TABLE IF NOT EXISTS item(
+    id int(11) NOT NULL AUTO_INCREMENT,
+    itemcode varchar(200) NOT NULL,
+    description varchar(200) NOT NULL,
+    itemgroup int NOT NULL,
+    uom int NOT NULL,
+
+    PRIMARY KEY(id,itemcode),
+    FOREIGN KEY (uom) REFERENCES uom(id)
+) ENGINE=INNODB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
+
+
+INSERT INTO customerType
+    (description)
+VALUES
+    ('Customer'),
+    ('Provider'),
+    ('Customer and Provider');
+
+INSERT INTO companyType
+    (description) 
+VALUES
+    ('Private'),
+    ('Public'),
+    ('General');
+
+INSERT INTO companySector(description)
+VALUES
+    ('Software & Technology'),
+    ('Transport'),
+    ('Retail'),
+    ('Food & Beverage'),
+    ('Tourism & Hospitality'),
+    ('Consumer Electronics'),
+    ('Cleaning items'),
+    ('Building tools'),
+    ('Medical');
+    
+
+INSERT INTO uom
+    (shortName,description) 
+VALUES
+    ('mtr','meter'),
+    ('qty','quantity'),
+    ('box','box'),
+    ('ltr','litre'),
+    ('ton','tonne'),
+    ('kg','kilogram'),
+    ('set','set'),
+    ('dia','inch diameter'),
+    ('mm','Milimeter thickness');
+
+INSERT INTO company(name,sector,type)
+VALUES 
+    ('Logo Yazilim',1,3),
+    ('patika.dev',1,3),
+    ('Sok',3,3),
+    ('A101',3,3),
+    ('Migros',3,3),
+    ('Bim',3,3),
+    ('CarrefourSA',3,3),
+    ('Makro center',3,3),
+    ('Mediamarkt',5,3),
+    ('TeknoSA',5,3),
+    ('Vatan Bilgisayar',5,3),
+    ('Baran yapi malzemeleri',8,3),
+    ('Ekrem Coskun doner',4,3),
+    ('Gunaydin Iskender',4,3),
+    ('Nurgul Eczanesi',9,3),
+    ('Lara Eczanesi',9,3),
+    ('Turk Hava yollari',2,3),
+    ('Pegasus Hava yollari',2,3),
+    ('Kamil Koc Seyahat',2,3),
+    ('Buzlu Turizm Seyahat',2,3),
+    ('Mardan Palace',5,3),
+    ('Sheraton Barut Hotel',5,3),
+    ('Arda temizlik malzemeleri',7,3);

--- a/docker-compose/docker-compose.yml
+++ b/docker-compose/docker-compose.yml
@@ -1,0 +1,41 @@
+version: "3.7"
+
+services:
+  #1- MySQL Database
+  mysql:
+    image: mysql
+    container_name: ib_mysql
+    restart: always
+    environment:
+      MYSQL_DATABASE: isbasi
+      MYSQL_ROOT_PASSWORD: 123456
+    ports:
+      - 8090:3306
+    volumes:
+      - "./default-tables.sql:/docker-entrypoint-initdb.d/default-tables.sql"
+
+  #2- phpMyAdmin
+  phpmyadmin:
+    image: phpmyadmin/phpmyadmin
+    container_name: ib_phpmyadmin
+    links:
+      - mysql
+    environment:
+      PMA_HOST: mysql
+      PMA_PORT: 3306
+      PMA_ARBITRARY: 1
+    restart: always
+    ports:
+      - 8091:80
+  
+  #3- Rabbit MQ
+  rabbitMQ:
+    image: rabbitmq:3-management
+    container_name: ib_rabbitmq
+    environment:
+      RABBITMQ_DEFAULT_PASS: 123456
+      RABBITMQ_DEFAULT_USER: user
+    restart: always
+    ports:
+      - 8092:15672
+    

--- a/docker-compose/killrestart
+++ b/docker-compose/killrestart
@@ -1,0 +1,5 @@
+sudo docker stop ib_mysql ib_phpmyadmin ib_rabbitmq
+sudo docker rm ib_mysql ib_phpmyadmin ib_rabbitmq
+sudo docker network rm ib_spinup_default
+sudo docker-compose up -d
+sudo docker ps

--- a/docker-compose/readme.txt
+++ b/docker-compose/readme.txt
@@ -1,0 +1,19 @@
+Docker compose dosyasi icinde 3 adet Container ayaga kalkacak.
+    1-PHPMyAdmin : mySQL veritabani icin grafik arayuzu
+    2-MySQL : veritabani
+    3-rabbitmq : Mesaj kuyruklama servisi
+
+bunlari yapabilmek icin bash scripte gecin, 
+    1- klasoru decompress yapip dosyalarin oldugu dizine bash ile gelin
+    2- bash script console ekraninda source killrestart yazin hepsini kendi kuracak.
+
+
+Container'lar ayaga kalktiktan sonra asagidaki bilgilerle erisebilirsiniz.
+    1. PhpMyAdmin , http://localhost:8090
+    2. mySQL ,port:8091 server: ib_mysql , username: root , password: 123456
+    2.1 default-tables.sql dosyasi mysql konteynirinda calistirilmis halde ayaga kalkacak
+    3. rabbitmq , http://localhost:8092
+
+default-tables.sql dosyasinin duzenlenmesi icin katki saglarsaniz gelistirme ortamimiz daha faydali olur.
+
+Umit Tas


### PR DESCRIPTION
Docker-compose file added
  +phpmyadmin
  +mysql
  +rabbitmq

Also default-tables.sql added for development environments, this will auto generate tables in mySQL while it spins up.
  +default-tables.sql 

Additionaly: bash script file created for stop, remove and freshly start containers and default network in docker-compose folder
  +source killrestart

please refer readme.txt in the docker-compose folder for used ports, username and passwords and access links to the containers
